### PR TITLE
Update AwsS3 contructor to consume any S3 option

### DIFF
--- a/src/Drivers/AwsS3.js
+++ b/src/Drivers/AwsS3.js
@@ -15,11 +15,11 @@ const Resetable = require('resetable')
  */
 class AwsS3 {
   constructor (config) {
-    this.s3 = new (require('aws-sdk/clients/s3'))({
+    this.s3 = new (require('aws-sdk/clients/s3'))(Object.assign({}, {
       accessKeyId: config.key,
       secretAccessKey: config.secret,
       region: config.region
-    })
+    }, config))
 
     this._bucket = new Resetable(config.bucket)
   }
@@ -206,13 +206,13 @@ class AwsS3 {
    */
   getUrl (location, bucket) {
     bucket = bucket || this._bucket.pull()
-    const { href } = this.s3.endpoint
-
-    if (href.startsWith('https://s3.amazonaws')) {
-      return `https://${bucket}.s3.amazonaws.com/${location}`
+    const { href, host, protocol } = this.s3.endpoint
+  
+    if (this.s3.config.region === null) {
+      return `${protocol}//${bucket}.${host}/${location}`
     }
 
-    return `${href}${bucket}/${location}`
+    return `${protocol}//${host}/${bucket}/${location}`
   }
 
   /**

--- a/tests/unit/s3-driver.spec.js
+++ b/tests/unit/s3-driver.spec.js
@@ -79,7 +79,7 @@ test.group('S3 Driver', () => {
       const s3Driver = new S3Driver(Object.assign({}, config, { secret: '2020' }))
       await s3Driver.put('dummy-file.txt', 'Hello')
     } catch (error) {
-      assert.equal(error.message, 'The request signature we calculated does not match the signature you provided. Check your key and signing method.')
+      assert.equal(error.code, 'SignatureDoesNotMatch')
     }
   }).timeout(0)
 
@@ -124,7 +124,7 @@ test.group('S3 Driver', () => {
     try {
       await readStream(stream)
     } catch (error) {
-      assert.equal(error.message, 'The specified key does not exist.')
+      assert.equal(error.code, 'NoSuchKey')
     }
   }).timeout(10 * 1000)
 


### PR DESCRIPTION
- Merge s3 options with default object
- Update `getUrl` method to utilize values from object
- Updated to spec to utilize `error.code` rather than `error.message`. 
  >When using something like Digital Ocean Spaces the message will be always be null.

**Note:**
The test `get public url to a file when region is not defined`, in my case, was never null. If `region` is set to a falsy value, s3 seems to always default to `us-east-1`. 